### PR TITLE
Change the package to use the new version of google's places auto complete

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,13 @@ export interface LatLng {
   lng: number;
 }
 
+export interface LocationRestriction {
+  north?: number,
+  south?: number,
+  west?: number,
+  east?: number,
+}
+
 export interface AutocompletionRequest {
   bounds?: [LatLng, LatLng];
   componentRestrictions?: { country: string | string[] };
@@ -19,6 +26,8 @@ export interface AutocompletionRequest {
   offset?: number;
   radius?: number;
   types?: string[];
+  locationRestriction?: LocationRestriction
+
 }
 
 export type Option = {


### PR DESCRIPTION
- This change is done because Google deprecated the bounds, locations, and radius from their new version. To fix the issue of the new version we need to change the package. This patch is for that

<details><summary>Bounds, location, and radius in the Maps JavaScript API Place Autocomplete Service (Deprecated as of May 2023)</summary>
<p>


For the Place Autocomplete Service in the Maps JavaScript API, the following request options are deprecated as of May 2023: bounds, location, and radius. Please use locationBias and locationRestriction instead.

The feature will continue to work, and 12 months notice will be given before support is discontinued.

</p>
</details> 

[Reference for this can be found here](https://developers.google.com/maps/deprecations#bounds_location_and_radius_in_the_place_autocomplete_service_deprecated_as_of_may_2023) 